### PR TITLE
Refactoring for command and event constructors and tests framework

### DIFF
--- a/src/EDA-Commands/EDADefaultCommandBuilder.class.st
+++ b/src/EDA-Commands/EDADefaultCommandBuilder.class.st
@@ -76,16 +76,19 @@ EDADefaultCommandBuilder >> copyFromBodyDict: aBodyDict intoCommand: aCommand [
 EDADefaultCommandBuilder >> copyFromDict: aDictionary intoCommand: aCommand [
 	aDictionary
 		associationsDo: [ :assoc |
-			| key |
-			key := assoc key.
-			[	aCommand
-					instVarNamed: key
-					put: assoc value
-					ifAbsent: [ self logWarningMessage: 'No such inst var: ' , key ] ]
-			on: Exception
-			do: [ :ex |
-				self
-					logWarningMessage: key greaseString , ' does not exist in ' , aCommand class greaseString ] ]
+			| key value |
+			value := assoc value.
+			"do not set the new value if it is nil to avoid removing the initialized values"
+			value ifNotNil: [
+				key := assoc key.
+				[	aCommand
+						instVarNamed: key
+						put: assoc value
+						ifAbsent: [ self logWarningMessage: 'No such inst var: ' , key ] ]
+				on: Exception
+				do: [ :ex |
+					self
+						logWarningMessage: key greaseString , ' does not exist in ' , aCommand class greaseString ] ] ]
 ]
 
 { #category : #building }

--- a/src/EDA-Domain-Tests/ATSCreateForm.extension.st
+++ b/src/EDA-Domain-Tests/ATSCreateForm.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #ATSCreateForm }
+
+{ #category : #'*EDA-Domain-Tests' }
+ATSCreateForm class >> attributesReceivedNotRequired [
+	^ Set with: #public
+]

--- a/src/EDA-Domain-Tests/ATSCreateForm.extension.st
+++ b/src/EDA-Domain-Tests/ATSCreateForm.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #ATSCreateForm }
-
-{ #category : #'*EDA-Domain-Tests' }
-ATSCreateForm class >> attributesReceivedNotRequired [
-	^ Set with: #public
-]

--- a/src/EDA-Domain-Tests/EDACommand.extension.st
+++ b/src/EDA-Domain-Tests/EDACommand.extension.st
@@ -1,0 +1,34 @@
+Extension { #name : #EDACommand }
+
+{ #category : #'*EDA-Domain-Tests' }
+EDACommand class >> attributesReceivedNotRequired [
+	"Overwrite if necessary with a set including the attributes received not required as symbols"
+	[ self subclassResponsibility ]
+		on: Error
+		do: [ ^ Set empty ]
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDACommand class >> instVarsNeededExceptionFor: aTest [
+	^ aTest commandInstVarsNeededException
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDACommand class >> instVarsNeededMessageFor: aTest [
+	^ aTest commandInstVarsNeededMessage
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDACommand class >> sampleFileNameForTest: aTest [
+	"overwrite if the sample file name does not follow the default criteria
+	e.g. <classPrefix>CommandNameUpperCamelCase -> command.name.upper.camel.case.example.json
+	"
+	[ self subclassResponsibility ]
+		on: Error
+		do: [ ^ aTest defaultSampleFileNameFor: self ]
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDACommand class >> sampleFilesPathForTest: aTest [
+	^ aTest commandSampleFilesPath
+]

--- a/src/EDA-Domain-Tests/EDACommandInstVarsNeeded.class.st
+++ b/src/EDA-Domain-Tests/EDACommandInstVarsNeeded.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #EDACommandInstVarsNeeded,
+	#superclass : #Error,
+	#category : #'EDA-Domain-Tests'
+}

--- a/src/EDA-Domain-Tests/EDADeleteAggregateCommand.extension.st
+++ b/src/EDA-Domain-Tests/EDADeleteAggregateCommand.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #EDADeleteAggregateCommand }
+
+{ #category : #'*EDA-Domain-Tests' }
+EDADeleteAggregateCommand class >> attributesReceivedNotRequired [
+	^ Set with: #delete
+]

--- a/src/EDA-Domain-Tests/EDAEventInstVarsNeeded.class.st
+++ b/src/EDA-Domain-Tests/EDAEventInstVarsNeeded.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #EDAEventInstVarsNeeded,
+	#superclass : #Error,
+	#category : #'EDA-Domain-Tests'
+}

--- a/src/EDA-Domain-Tests/EDAEventSourcingEvent.extension.st
+++ b/src/EDA-Domain-Tests/EDAEventSourcingEvent.extension.st
@@ -16,6 +16,37 @@ EDAEventSourcingEvent >> asJsonString [
 ]
 
 { #category : #'*EDA-Domain-Tests' }
+EDAEventSourcingEvent class >> attributesReceivedNotRequired [
+	"Not need for events"
+	^ Set empty
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDAEventSourcingEvent class >> instVarsNeededExceptionFor: aTest [
+	^ aTest eventInstVarsNeededException
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDAEventSourcingEvent class >> instVarsNeededMessageFor: aTest [
+	^ aTest eventInstVarsNeededMessage
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDAEventSourcingEvent class >> sampleFileNameForTest: aTest [
+	"overwrite if the sample file name does not follow the default criteria
+	e.g. <classPrefix>EventNameUpperCamelCase -> event.name.upper.camel.case.example.json
+	"
+	[ self subclassResponsibility ]
+		on: Error
+		do: [ ^ aTest defaultSampleFileNameFor: self ]
+]
+
+{ #category : #'*EDA-Domain-Tests' }
+EDAEventSourcingEvent class >> sampleFilesPathForTest: aTest [
+	^ aTest eventSampleFilesPath
+]
+
+{ #category : #'*EDA-Domain-Tests' }
 EDAEventSourcingEvent >> totallyMatches: anObject forTest: aTest [
 	^ aTest event: self totallyMatchesWith: anObject
 ]

--- a/src/EDA-Domain-Tests/EDAIncompleteCommand.class.st
+++ b/src/EDA-Domain-Tests/EDAIncompleteCommand.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #EDAIncompleteCommand,
+	#superclass : #Error,
+	#category : #'EDA-Domain-Tests'
+}

--- a/src/EDA-Domain-Tests/EDAMismatchError.class.st
+++ b/src/EDA-Domain-Tests/EDAMismatchError.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #EDAMismatchError,
+	#superclass : #Error,
+	#instVars : [
+		'diff'
+	],
+	#category : #'EDA-Domain-Tests'
+}
+
+{ #category : #exceptioninstantiator }
+EDAMismatchError class >> signal: message withDiff: aDiff [
+	"Signal the occurrence of an exceptional condition with a specified textual description and diff"
+
+	^ self new diff: aDiff; signal: message
+]
+
+{ #category : #accessing }
+EDAMismatchError >> diff [
+	^ diff
+]
+
+{ #category : #accessing }
+EDAMismatchError >> diff: anObject [
+	diff := anObject
+]

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -1,7 +1,6 @@
 Trait {
 	#name : #EDATDomainBDD,
 	#traits : 'EDATLogging + EDATRegexHelper',
-	#classTraits : 'EDATLogging classTrait + EDATRegexHelper classTrait',
 	#category : #'EDA-Domain-Tests'
 }
 

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -5,6 +5,12 @@ Trait {
 	#category : #'EDA-Domain-Tests'
 }
 
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> InstVarsNeededMessage [
+	^ [ :instvars :className | 'Check creation of instance variables: ' , instvars 
+						, ' and accessors for class ' , className , ' or add them to its attributesReceivedNotRequired' ]
+]
+
 { #category : #'matching helpers' }
 EDATDomainBDD >> anyUnnecessaryCheck: aCollection [
 	^ aCollection anySatisfy: [ :elem | self unnecessaryCheck: elem ]
@@ -53,6 +59,16 @@ EDATDomainBDD >> areSameEventType: anEvent and: otherEvent [
 	^ (anEvent isKindOf: otherEvent class) or: [ otherEvent isKindOf:  anEvent class ]
 ]
 
+{ #category : #'matching helpers' }
+EDATDomainBDD >> assertEvent: actual deepMatches: expected [
+	"This method raises an AssertionFailure if actual event is different (using #event:totallyMatchesWith: message) from expected.
+	 Else it does nothing and execution continues.
+	"
+	[ self event: expected totallyMatchesWith: actual ]
+		on: EDAMismatchError
+		do: [ self assert: expected asJsonString equals: actual asJsonString ]
+]
+
 { #category : #BDD }
 EDATDomainBDD >> assertEvent: actual equals: expected [
 	| diff |
@@ -91,6 +107,60 @@ EDATDomainBDD >> buildBodyForCommand: aCommand andAggregateRootVersion: aVersion
 
 ]
 
+{ #category : #'helper - command building' }
+EDATDomainBDD >> buildCommandAttributesDictFromMessage: aCommandMessage [
+
+	| commandJson commandMeta commandBody |
+	commandJson := NeoJSONReader fromString: aCommandMessage.
+	commandMeta := commandJson at: #meta.
+	commandBody := commandJson at: #body.
+	"It is the aggregateRootClass. Known by ATS<Command> class >> aggregateRootClass"
+	commandMeta removeKey: #aggregate ifAbsent: [ ].
+	commandMeta removeKey: #type ifAbsent: [ ].
+	commandMeta removeKey: #correlationId ifAbsent: [ ].
+	"It is the command message id."
+	commandMeta changeKey: #id to: #commandId.
+	commandMeta changeKey: #timestamp to: #originalTimestamp.
+	"Transform to DateAndTime"
+	commandMeta
+		at: #originalTimestamp 
+		ifPresent: [ :time |
+			commandMeta at: #originalTimestamp put: (DateAndTime fromString: time) ].
+	commandBody changeKey: #id to: #aggregateRootId.
+	commandBody changeKey: #version to: #aggregateRootVersion.
+	^ commandMeta | commandBody
+]
+
+{ #category : #'helper - event building' }
+EDATDomainBDD >> buildEventAttributesDictFromFile: aFile [
+
+	| eventMessage eventJson eventMeta eventBody |
+	eventMessage := self readFile: aFile.
+	eventJson := NeoJSONReader fromString: eventMessage.
+	eventMeta := eventJson at: #meta.
+	eventBody := eventJson at: #body.
+	"It is the event message id. Not necessary to materialize event objet"
+	eventMeta removeKey: #id ifAbsent: [ ].
+	"It is the aggregateRootClass. Known by ATS<Event> class >> aggregateRootClass"
+	eventMeta removeKey: #aggregate ifAbsent: [ ].
+	"It is the class. Not necessary to materialize event objet. Already known"
+	eventMeta removeKey: #type ifAbsent: [ ].
+	eventMeta changeKey: #correlationId to: #commandId.
+	eventBody changeKey: #version to: #aggregateRootVersion.
+	eventBody
+		at: #timestamp
+		ifPresent: [ :bodyTimestamp |
+			bodyTimestamp
+				ifNil: [ 
+					eventMeta at: #timestamp ifAbsentPut: [ nil ].
+					eventBody removeKey: #timestamp ]
+				ifNotNil: [
+					eventMeta removeKey: #timestamp ifAbsent: [  ] ] ].
+
+		
+	^ eventMeta | eventBody
+]
+
 { #category : #helper }
 EDATDomainBDD >> buildMessageForCommand: aCommand ofType: aString [
 	| aux |
@@ -120,63 +190,304 @@ EDATDomainBDD >> buildMetaForCommand: aCommand ofType: aString [
 	^ meta
 ]
 
+{ #category : #'helper - command building' }
+EDATDomainBDD >> buildSampleCommandFor: aCommandClass [
+	| commandMessage |
+	commandMessage := self readSampleFileFor: aCommandClass.
+	self checkInstVarsFor: aCommandClass withAttributes: (self buildCommandAttributesDictFromMessage: commandMessage).
+	^ ATSJsonCommandMaterializer new materialize: commandMessage.
+]
+
+{ #category : #'helper - event building' }
+EDATDomainBDD >> buildSampleEventFor: anEventClass [
+	| attributes |
+	attributes := self
+		buildEventAttributesDictFromFile: (self readSampleFileFor: anEventClass).
+	self checkInstVarsFor: anEventClass withAttributes: attributes.
+	^ anEventClass
+		ofTenant: (attributes at: #tenant)
+		withAggregateId: (attributes at: #id)
+		commandId: (attributes at: #commandId)
+		andAttributes: attributes
+	"	| eventMessage eventJson eventMeta eventBody evtAttributes evtCommandId evtTenant evtId evtTimestamp |
+	eventMessage := self readFile: aFile.
+	eventJson := NeoJSONReader fromString: eventMessage.
+	eventMeta := eventJson at: #meta.
+	eventBody := eventJson at: #body.
+	evtAttributes := Dictionary new.
+	evtAttributes at: 'version' put: (eventMeta at: 'version').
+	evtAttributes at: 'aggregateRootVersion' put: (eventBody at: 'version').
+	evtTenant := eventBody at: 'tenant'.
+	evtId := eventBody at: 'id'.
+	evtCommandId := eventMeta at: 'correlationId' ifAbsent: [ 'missing' ].
+	evtTimestamp := eventBody at: 'timestamp' ifAbsent: [ nil ].
+	evtTimestamp ifNil: [ evtTimestamp := eventMeta at: 'timestamp' ifAbsent: [ nil ] ].
+	evtTimestamp ifNotNil: [ :t | evtAttributes at: 'timestamp' put: evtTimestamp ].
+	eventBody at: #scopeContext ifPresent: [ :v | evtAttributes at: #scopeContext put: v ].
+	eventBody at: #scopeKey ifPresent: [ :v | evtAttributes at: #scopeKey put: v ].
+	eventBody at: 'canSaveDraft' ifPresent: [ :v | evtAttributes at: 'canSaveDraft' put: v ].
+	eventBody at: 'confirmationMessage' ifPresent: [ :v | evtAttributes at: 'confirmationMessage' put: v ].
+	eventBody at: 'contestId' ifPresent: [ :v | evtAttributes at: 'contestId' put: v ].
+	eventBody at: 'contestKey' ifPresent: [ :v | evtAttributes at: 'contestKey' put: v ].
+	eventBody at: 'contestName' ifPresent: [ :v | evtAttributes at: 'contestName' put: v ].
+	eventBody at: 'defaultLanguage' ifPresent: [ :v | evtAttributes at: 'defaultLanguage' put: v ].
+	eventBody at: 'formKey' ifPresent: [ :v | evtAttributes at: 'formKey' put: v ].
+	eventBody at: 'gdpr' ifPresent: [ :v | evtAttributes at: 'gdpr' put: v ].
+	eventBody at: 'languages' ifPresent: [ :v | evtAttributes at: 'languages' put: v ].
+	eventBody at: 'legalConditions' ifPresent: [ :v | evtAttributes at: 'legalConditions' put: v ].
+	eventBody at: 'public' ifPresent: [ :v | evtAttributes at: 'public' put: v ].
+	eventBody at: 'recoveryZone' ifPresent: [ :v | evtAttributes at: 'recoveryZone' put: v ].
+	eventBody at: 'sections' ifPresent: [ :v | evtAttributes at: 'sections' put: v ].
+	eventBody at: 'sendingDataMessage' ifPresent: [ :v | evtAttributes at: 'sendingDataMessage' put: v ].
+	eventBody at: 'showAllowShareDataCheck' ifPresent: [ :v | evtAttributes at: 'showAllowShareDataCheck' put: v ].
+	eventBody at: 'summarySentence' ifPresent: [ :v | evtAttributes at: 'summarySentence' put: v ].
+	eventBody at: 'timeoutErrorMessage' ifPresent: [ :v | evtAttributes at: 'timeoutErrorMessage' put: v ].
+	eventBody at: 'widgetCustomizations' ifPresent: [ :v | evtAttributes at: 'widgetCustomizations' put: v ].
+"
+]
+
+{ #category : #'helper - event building' }
+EDATDomainBDD >> buildSampleEventFor: anEventClass withId: evtId andCommandId: inputCommandId [
+
+	| aTestEvt |
+	aTestEvt := self buildSampleEventFor: anEventClass.
+	aTestEvt id: evtId.
+	aTestEvt commandId: inputCommandId.
+	^ aTestEvt
+"
+	| result |
+	result := ATSTestFormCreated fromEvent: (self buildFormCreatedEventFromFile: self readFormCreatedFromFile).
+	result id: evtId.
+	result commandId: inputCommandId.
+	^ result
+"
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> checkInstVarsFor: aCommandOrEventClass withAttributes: attributes [
+	| newInstVarsNeeded |
+	newInstVarsNeeded := self
+		newInstVarNeededFor: aCommandOrEventClass
+		withAttributes: attributes.
+	newInstVarsNeeded
+		ifNotEmpty: [ :instvars | 
+			self
+				logErrorMessage: ((aCommandOrEventClass instVarsNeededMessageFor: self) value: instvars greaseString value: aCommandOrEventClass name)
+				andThrow: (aCommandOrEventClass instVarsNeededExceptionFor: self) ]
+	"	Automatic creation
+	newInstVarsNeeded 
+		do: [ :instVarName | 
+			self addInstVarNamed: instVarName greaseString.
+			formCreatedTestEvt
+				instVarNamed: instVarName greaseString
+				put: (theAttrs at: instVarName)
+				ifAbsent: [ self logDebugMessage: 'No instVar created' ] ]."
+]
+
+{ #category : #'matching helpers - logs' }
+EDATDomainBDD >> checkingLogForType: typeToCheckAsString element: aElement and: otherElement [
+	^ 'Checking match ' , typeToCheckAsString , ' [' , aElement fullPrintString , '] with [' , otherElement fullPrintString , ']'
+]
+
 { #category : #'matching helpers' }
 EDATDomainBDD >> collection: aCollection totallyMatchesWith: otherObject [
-	| elemsToCheck size |
+	| checkingType collectionDiffMessage collectionDiffDict elemsToCheck size |
 	self flag: #TODO.
-	"At the moment it seems that we only need it for SequenceableCollection. See in the future for Bag, etc."
-	self logDebugMessage: 'Checking match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString.
-	elemsToCheck := (OrderedCollection with: aCollection with: otherObject).
-	(self anyUnnecessaryCheck: elemsToCheck) ifTrue: [ ^ true ].
-	aCollection == otherObject
+	"At the moment it seems that we only need it for SequenceableCollection. See in the future for Bag, Set, etc."
+	checkingType := aCollection className.
+	collectionDiffMessage := String empty.
+	collectionDiffDict := Dictionary empty.
+	self logDebugMessage: (self checkingLogForType: checkingType element: aCollection and: otherObject).
+	elemsToCheck := OrderedCollection with: aCollection with: otherObject.
+	(self anyUnnecessaryCheck: elemsToCheck)
 		ifTrue: [ 
+			self unnecesaryCheckLogForType: checkingType element: aCollection and: otherObject.
+			^ self ].
+	aCollection == otherObject
+		ifTrue: [
 			self logDebugMessage: 'Match by identity'.
-			^ true ].
+			^ self ].
 	"It gives problems with OrderedCollection <> Array
 	aCollection species == otherObject species ifFalse: [ ^ false ]."
 	(otherObject isKindOf: SequenceableCollection)
-		ifFalse: [ 
-			self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by not SequenceableCollection'.
-			^ false ].
+		ifFalse: [ | mismatchTypeLogMessage |
+			mismatchTypeLogMessage := self
+				mismatchCheckLogForType: checkingType
+				element: aCollection
+				and: otherObject
+				andReason: 'different types'.
+			self logDebugMessage: mismatchTypeLogMessage.
+			collectionDiffDict add: aCollection -> otherObject.
+			EDAMismatchError
+				signal: mismatchTypeLogMessage
+				withDiff: collectionDiffDict ].
 	(size := aCollection size) = otherObject size
-		ifFalse: [ 
-			self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by different sizes'.
-			^ false ].
+		ifFalse: [ | mismatchTypeLogMessage |
+			mismatchTypeLogMessage := self
+				mismatchCheckLogForType: checkingType
+				element: aCollection
+				and: otherObject
+				andReason: 'different sizes'.
+			self logDebugMessage: mismatchTypeLogMessage.
+			collectionDiffDict add: aCollection -> otherObject.
+			EDAMismatchError
+				signal: mismatchTypeLogMessage
+				withDiff: collectionDiffDict ].
 	"Done like this instead of with allSatisfy: to get all the different values in the future and show them on the visualization"
-	1 to: size do: [ :index |
-		((aCollection at: index) totallyMatches: (otherObject at: index) forTest: self)
-			ifFalse: [ 
-				self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by elements'.
-				^ false ] ].
-	^ true
+	1 to: size do: [ :index | 
+		| aCollectionElement otherCollectionElement |
+		aCollectionElement := aCollection at: index.
+		otherCollectionElement := otherObject at: index.
+		[ aCollectionElement
+			totallyMatches: otherCollectionElement
+			forTest: self ]
+			on: EDAMismatchError
+			do: [ :ex | 
+				| elementType mismatchElementMessage |
+				elementType := String
+					streamContents: [ :s | 
+						s
+							nextPutAll: '#';
+							nextPutAll: index greaseString;
+							nextPutAll: ' collection elements' ].
+				mismatchElementMessage := self
+					mismatchCheckLogForType: elementType
+					element: aCollectionElement
+					and: otherCollectionElement
+					andReason: ''.
+				self logDebugMessage: mismatchElementMessage.
+				collectionDiffDict at: #index put: ex diff.
+				collectionDiffMessage := String
+					streamContents: [ :s | 
+						s
+							nextPutAll: collectionDiffMessage;
+							nextPutAll: (String with: Character cr with: Character lf);
+							nextPutAll: mismatchElementMessage;
+							nextPutAll: (String with: Character cr with: Character lf);
+							nextPutAll: ex messageText;
+							nextPutAll: (String with: Character cr with: Character lf) ] ] ].
+	collectionDiffDict
+		ifNotEmpty: [ | mismatchCollectionMessage |
+			mismatchCollectionMessage := self mismatchCheckLogForType: checkingType element: aCollection and: otherObject andReason: 'elements mismatch'.
+			self logDebugMessage: mismatchCollectionMessage.
+			collectionDiffMessage := String
+				streamContents: [ :s | 
+					s
+						nextPutAll: mismatchCollectionMessage;
+						nextPutAll: (String with: Character cr with: Character lf with: Character tab);
+						nextPutAll: collectionDiffMessage ].
+			EDAMismatchError
+				signal: collectionDiffMessage
+				withDiff: collectionDiffDict ]
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> commandInstVarsNeededException [
+	^ EDACommandInstVarsNeeded
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> commandInstVarsNeededMessage [
+	^ [ :instvars :className | 'Check creation of instance variables: ' , instvars 
+						, ' and accessors for class ' , className , ' or add them to its attributesReceivedNotRequired' ]
+]
+
+{ #category : #'helper - file readers' }
+EDATDomainBDD >> commandSampleFilesPath [
+	^ FileSystem disk workingDirectory / 'contracts' / 'Core' / 'commands'
+]
+
+{ #category : #'helper - file readers' }
+EDATDomainBDD >> defaultSampleFileNameFor: aCommandOrEventClass [
+	| classNamePrefixRemoved |
+	
+	"e.g. <classPrefix>CommandoreventNameUpperCamelCase -> commandorevent.name.upper.camel.case.example.json"
+	"EDATLanguageHelper class >> removePrefix:from:
+	EDASourceCodeHelperStub >> separateCamelCase:with:"
+	classNamePrefixRemoved :=  ('^' , aCommandOrEventClass classPrefix copyReplaceAll: ':' with: '\:') asRegexIgnoringCase copy: aCommandOrEventClass name replacingMatchesWith: ''.
+	^ ((classNamePrefixRemoved copyWithRegex: '[A-Z]' matchesTranslatedUsing: [ :each | '.' , each asLowercase  ]) allButFirst) , '.example.json'.
 ]
 
 { #category : #'matching helpers' }
 EDATDomainBDD >> dictionary: aDictionary totallyMatchesWith: otherObject [
-	| aCollection |
-	self logDebugMessage: 'Checking match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString.
+	| checkingType dictionaryDiffMessage dictionaryDiffDict aCollection |
+	checkingType := aDictionary className.
+	dictionaryDiffMessage := String empty.
+	dictionaryDiffDict := Dictionary empty.
+	self logDebugMessage: (self checkingLogForType: checkingType element: aDictionary and: otherObject).
 	aCollection := (OrderedCollection with: aDictionary with: otherObject).
-	(self anyUnnecessaryCheck: aCollection) ifTrue: [ ^ true ].
+	(self anyUnnecessaryCheck: aCollection)
+		ifTrue: [
+			self unnecesaryCheckLogForType: checkingType element: aDictionary and: otherObject.
+			^ self ].
 	aDictionary == otherObject 
 		ifTrue: [ 
 			self logDebugMessage: 'Match by identity'.
-			^ true ].
-	aDictionary species == otherObject species
-		ifFalse: [
-			self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by different species'.
-			^ false ].
-	(otherObject isKindOf: Dictionary) ifFalse: [ ^ false ].
+			^ self ].
+	((aDictionary species ~~ otherObject species) or: [ (otherObject isKindOf: Dictionary) not ])
+		ifTrue: [ | mismatchTypeLogMessage |
+			mismatchTypeLogMessage := self
+				mismatchCheckLogForType: checkingType
+				element: aDictionary
+				and: otherObject
+				andReason: 'different types'.
+			self logDebugMessage: mismatchTypeLogMessage.
+			dictionaryDiffDict add: aDictionary -> otherObject.
+			EDAMismatchError signal: mismatchTypeLogMessage withDiff: dictionaryDiffDict ].
 	aDictionary size = otherObject size
-		ifFalse: [ 
-			self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by different sizes'.
-			^ false ].
+		ifFalse: [ | mismatchTypeLogMessage |
+			mismatchTypeLogMessage := self mismatchCheckLogForType: checkingType element: aCollection and: otherObject andReason: 'different sizes'.
+			self logDebugMessage: mismatchTypeLogMessage.
+			dictionaryDiffDict add: aDictionary -> otherObject.
+			EDAMismatchError
+				signal: mismatchTypeLogMessage
+				withDiff:dictionaryDiffDict ].
 	"Done like this instead of with allSatisfy: to get all the different values in the future and show them on the visualization"
 	aDictionary associationsDo: [ :assoc |
-		(assoc value totallyMatches: (otherObject at: assoc key ifAbsent: [ ^ false ]) forTest: self)
-			ifFalse: [
-				self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by elements'. 
-				^ false ] ].
-	^ true
+		| assocType aValue |
+		assocType := String streamContents: [ :s | s nextPutAll: '#'; nextPutAll: assoc key greaseString; nextPutAll: ' dictionary association' ].
+		aValue := assoc value.
+		otherObject at: assoc key
+			ifPresent: [ :otherValue |
+				| mismatchValueMessage |
+				[ aValue totallyMatches: otherValue forTest: self ]
+					on: EDAMismatchError
+					do: [ :ex |
+						mismatchValueMessage := self mismatchCheckLogForType: assocType element: aValue and: otherValue andReason: ''.
+						self logDebugMessage: mismatchValueMessage.
+						dictionaryDiffDict at: assoc key put: ex diff.
+						dictionaryDiffMessage := String
+							streamContents: [ :s | 
+							s
+								nextPutAll: dictionaryDiffMessage;
+								nextPutAll: (String with: Character cr with: Character lf);
+								nextPutAll: mismatchValueMessage;
+								nextPutAll: (String with: Character cr with: Character lf);
+								nextPutAll: ex messageText;
+								nextPutAll: (String with: Character cr with: Character lf) ] ] ]
+			ifAbsent: [ | mismatchKeyMessage |
+				mismatchKeyMessage := self mismatchCheckLogForType: assocType element: assoc and: 'absent' andReason: 'missing key'.
+				self logDebugMessage: mismatchKeyMessage.
+				dictionaryDiffDict at: assoc key put: 'Absent'.
+				dictionaryDiffMessage := String
+					streamContents: [ :s | 
+						s
+							nextPutAll: dictionaryDiffMessage;
+							nextPutAll: (String with: Character cr with: Character lf);
+							nextPutAll: mismatchKeyMessage;
+							nextPutAll: (String with: Character cr with: Character lf) ] ] ].
+	dictionaryDiffDict
+		ifNotEmpty: [ | mismatchDictionaryMessage |
+			mismatchDictionaryMessage := self mismatchCheckLogForType: checkingType element: aDictionary and: otherObject andReason: 'associations mismatch'.
+			self logDebugMessage: mismatchDictionaryMessage.
+			dictionaryDiffMessage := String
+				streamContents: [ :s | 
+					s
+						nextPutAll: mismatchDictionaryMessage;
+						nextPutAll: (String with: Character cr with: Character lf with: Character tab);
+						nextPutAll: dictionaryDiffMessage  ].
+			EDAMismatchError signal: dictionaryDiffMessage withDiff: dictionaryDiffDict ].
+
 ]
 
 { #category : #helper }
@@ -193,29 +504,78 @@ EDATDomainBDD >> discardDateCreated: anEvent [
 
 { #category : #'matching helpers' }
 EDATDomainBDD >> event: anEvent totallyMatchesWith: otherEvent [
-	| eventCollection |
-	self logCheckingEvent: anEvent and: otherEvent.
+	| checkingType eventDiffDict eventDiffMessage eventCollection |
+	checkingType := anEvent className.
+	eventDiffDict := Dictionary empty.
+	eventDiffMessage := String empty.
+	self checkingLogForType: 'event' element: anEvent and: otherEvent.
 	eventCollection := OrderedCollection with: anEvent with: anEvent.
 	(self anyUnnecessaryCheck: eventCollection)
-		ifTrue: [ ^ true ].
+		ifTrue: [
+			self logDebugMessage: (self unnecesaryCheckLogForType: 'event' element: anEvent and: otherEvent).
+			^ self ].
 	(self areSameEventType: anEvent and: otherEvent)
-		ifFalse: [ self
-				logDebugMessage:
-					'No match event ' , anEvent fullPrintString , ' with '
-						, otherEvent fullPrintString , ' by different event type'.
-			^ false ].
-	^ anEvent class allInstVarNames
-		allSatisfy: [ :varName | 
-			((varName value: anEvent)
-				totallyMatches: (varName value: otherEvent)
-				forTest: self)
-				or: [ | attributeGenerated |
-					attributeGenerated := anEvent class
-						isEventGenerated: varName greaseString.
-					attributeGenerated
+		ifFalse: [ | mismatchTypeLogMessage |
+			mismatchTypeLogMessage := self mismatchCheckLogForType: checkingType element: anEvent and: otherEvent andReason: 'by different types'.
+			self logDebugMessage: mismatchTypeLogMessage.
+			eventDiffMessage add: anEvent -> otherEvent.
+			EDAMismatchError signal: mismatchTypeLogMessage withDiff: eventDiffMessage ].
+	anEvent class allInstVarNames
+		do: [ :varName | 
+			| checkingInstVarMessage anEventVar otherEventVar |
+			anEventVar := varName value: anEvent.
+			otherEventVar := varName value: otherEvent.
+			checkingInstVarMessage := self checkingLogForType: 'instance variable' element: anEventVar and: otherEventVar.
+			self logDebugMessage: checkingInstVarMessage.
+			[ anEventVar totallyMatches: otherEventVar forTest: self ]
+				on: EDAMismatchError
+				do: [ :ex | 
+					(anEvent class isEventGenerated: varName greaseString)
 						ifTrue: [ self
-								logDebugMessage: 'Match by ' , varName fullPrintString , ' event generated' ].
-					attributeGenerated ] ]
+								logDebugMessage:
+									(String
+										streamContents: [ :stream | 
+											stream
+												nextPutAll: 'Match by ';
+												nextPutAll: varName fullPrintString;
+												nextPutAll: ' event generated' ]) ]
+						ifFalse: [ | mismatchInstVarMessage |
+							mismatchInstVarMessage := self mismatchCheckLogForType: varName element: anEventVar and: otherEventVar andReason: ''.
+							self logDebugMessage: mismatchInstVarMessage.
+							eventDiffDict at: varName put: ex diff.
+							eventDiffMessage := String
+								streamContents: [ :s | 
+									s
+										nextPutAll: eventDiffMessage;
+										nextPutAll: String crlf; nextPutAll: String tab;
+										nextPutAll: mismatchInstVarMessage;
+										nextPutAll: String crlf; nextPutAll: String tab;
+										nextPutAll: ex messageText;
+										nextPutAll: String crlf ] ] ].
+			self logDebugMessage: (String streamContents: [ :s | s nextPutAll: 'Match '; nextPutAll: varName greaseString ]) ].
+	eventDiffDict ifNotEmpty: [ 
+		eventDiffMessage := String 
+			streamContents: [ :s | s
+				nextPutAll: (self mismatchCheckLogForType: checkingType element: anEvent and: otherEvent  andReason: 'instance variables mismatch');
+				nextPutAll: String crlf; nextPutAll: String tab;
+				nextPutAll: eventDiffMessage ].
+		EDAMismatchError signal: eventDiffMessage withDiff: eventDiffDict ]
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> eventInstVarsNeededException [
+	^ EDAEventInstVarsNeeded
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> eventInstVarsNeededMessage [
+	^ [ :instvars :className | 'Check creation of instance variables: ' , instvars 
+						, ' and accessors for class ' , className ]
+]
+
+{ #category : #'helper - file readers' }
+EDATDomainBDD >> eventSampleFilesPath [
+	^ FileSystem disk workingDirectory / 'contracts' / 'Core' / 'events'
 ]
 
 { #category : #helper }
@@ -334,13 +694,15 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 	self assert: resultingEvents size equals: expectedEvents size.
 	resultingEvents
 		keysAndValuesDo: [ :i :actual | 
-			| expected |
+			| expected matchResult |
 			expected := expectedEvents at: i.
 			self discardDateCreated: expected.
 			self discardAgent: expected.
-			(self event: expected totallyMatchesWith: actual)
+			self assertEvent: expected deepMatches: actual.
+			"matchResult := self event: expected totallyMatchesWith: actual.
+			(matchResult at: #match)
 			 ifFalse: [ 
-				self assert: expected asJsonString equals: actual asJsonString ].
+				self assert: expected asJsonString = actual asJsonString description: [ matchResult at: #diff ] ]."
 			"Keep for testing with old system"
 			"self assert: expected asJsonString equals: actual asJsonString."
 			"self assertEvent: expected equals: actual."
@@ -349,20 +711,52 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 		ensure: [ self restoreEventStores: originalEventStores ]
 ]
 
+{ #category : #'matching helpers - logs' }
+EDATDomainBDD >> mismatchCheckLogForType: typeToCheckAsString element: anEvent and: otherEvent andReason: aReasonAsString [
+	^ 'No match ' , typeToCheckAsString , ' [' , anEvent fullPrintString , '] with [' , otherEvent fullPrintString , '] by reason: ' , aReasonAsString
+]
+
 { #category : #'matching helpers' }
-EDATDomainBDD >> logCheckingEvent: anEvent and: otherEvent [
-	self logDebugMessage: 'Checking match event ' , anEvent fullPrintString , ' with ' , otherEvent fullPrintString.
+EDATDomainBDD >> mismatchInstVarMessage [
+	^ [ :varName :anEventVar :otherEventVar | 
+		String streamContents: [ :s |
+			s nextPutAll: 'No match ';
+			nextPutAll: varName greaseString;
+			nextPut: Character cr;
+			nextPut: Character lf;
+			nextPutAll: anEventVar greaseString;
+			nextPut: Character cr;
+			nextPut: Character lf;
+			nextPutAll: ' with ';
+			nextPut: Character cr;
+			nextPut: Character lf;
+			nextPutAll: otherEventVar greaseString ] ]
+]
+
+{ #category : #'helper - inst var checking' }
+EDATDomainBDD >> newInstVarNeededFor: aCommandOrEventClass withAttributes: theAttrs [
+	| receivedAttributes newInstVars |
+	receivedAttributes := (theAttrs keys collect: [ :each | each asSymbol ]).
+	newInstVars := (receivedAttributes \ aCommandOrEventClass attributesReceivedNotRequired) \ (aCommandOrEventClass allInstVarNames collect: [ :each | each asSymbol ]).
+	^ newInstVars
 ]
 
 { #category : #'matching helpers' }
 EDATDomainBDD >> object: anObject totallyMatchesWith: otherObject [
-	| aCollection objectsEquality |
-	self logDebugMessage: 'Checking match object ' , anObject fullPrintString , ' with ' , otherObject fullPrintString.
+	| checkingType logs aCollection |
+	checkingType := anObject className.
+	logs := anObject isCharacter not.
+	logs ifTrue: [ self logDebugMessage: (self checkingLogForType: checkingType element: anObject and: otherObject) ].
 	aCollection := (OrderedCollection with: anObject with: otherObject).
-	(self anyUnnecessaryCheck: aCollection) ifTrue: [ ^ true ].
-	objectsEquality := anObject = otherObject.
-	self logDebugMessage: (objectsEquality ifTrue: [ 'Match ' ] ifFalse: [ 'Dismatch ' ]) , ' by identity'.
-	^ objectsEquality
+	(self anyUnnecessaryCheck: aCollection)
+		ifTrue: [ 
+			self unnecesaryCheckLogForType: checkingType element: anObject and: otherObject.
+			^ self ].
+	anObject = otherObject
+		ifTrue: [ logs ifTrue: (self logDebugMessage: 'Match by identity') ]
+		ifFalse: [ | mismatchObjectMessage |
+			mismatchObjectMessage := self mismatchCheckLogForType: checkingType element: anObject and: otherObject andReason: 'not identity'.
+			EDAMismatchError signal: mismatchObjectMessage withDiff: (Dictionary with: anObject -> otherObject) ]
 
 ]
 
@@ -383,13 +777,19 @@ EDATDomainBDD >> provideAggregateRootVersion: aggregateRootVersion to: aString [
 	^ self replaceIn: aString allMatches: '\$\{AGGREGATE_ROOT_VERSION\}' with: aggregateRootVersion
 ]
 
-{ #category : #helper }
+{ #category : #'helper - file readers' }
 EDATDomainBDD >> readFile: aFile [
 	| fileStream result |
 	fileStream := aFile readStream.
 	result := fileStream contents.
 	fileStream close.
 	^ result
+]
+
+{ #category : #'helper - file readers' }
+EDATDomainBDD >> readSampleFileFor: aCommandOrEventClass [
+	^ self readFile: ((aCommandOrEventClass sampleFilesPathForTest: self) / ('v' , aCommandOrEventClass latestVersion asString) / (aCommandOrEventClass sampleFileNameForTest: self))
+
 ]
 
 { #category : #'test support' }
@@ -430,6 +830,11 @@ EDATDomainBDD >> retrieveHandlerSelectorSymbol: aCommand [
 	^ result
 ]
 
+{ #category : #'matching helpers - logs' }
+EDATDomainBDD >> unnecesaryCheckLogForType: typeToCheckAsString element: anEvent and: otherEvent [
+	^ 'Unnecesary Check for ' , typeToCheckAsString , ' [' , anEvent fullPrintString , '] and [' , otherEvent fullPrintString , ']'
+]
+
 { #category : #'matching helpers' }
 EDATDomainBDD >> unnecessaryCheck: anObject [
 	| isUnnecessary |
@@ -449,4 +854,124 @@ EDATDomainBDD >> wildCards [
 	^ Set
 		with: '<ANYTHING>'
 		with: '1970-01-01T00:00:00'.
+]
+
+{ #category : #'matching helpers' }
+EDATDomainBDD >> working_collection: aCollection totallyMatchesWith: otherObject [
+	| differences elemsToCheck size |
+	self flag: #TODO.
+	"At the moment it seems that we only need it for SequenceableCollection. See in the future for Bag, Set, etc."
+	differences := Dictionary with: #match -> true with: #diff -> nil.
+	self logDebugMessage: 'Checking match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString.
+	elemsToCheck := (OrderedCollection with: aCollection with: otherObject).
+	(self anyUnnecessaryCheck: elemsToCheck) ifTrue: [ ^ true ].
+	aCollection == otherObject
+		ifTrue: [ 
+			self logDebugMessage: 'Match by identity'.
+			^ true ].
+	"It gives problems with OrderedCollection <> Array
+	aCollection species == otherObject species ifFalse: [ ^ false ]."
+	(otherObject isKindOf: SequenceableCollection)
+		ifFalse: [ 
+			self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by not SequenceableCollection'.
+			^ false ].
+	(size := aCollection size) = otherObject size
+		ifFalse: [ 
+			self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by different sizes'.
+			^ false ].
+	"Done like this instead of with allSatisfy: to get all the different values in the future and show them on the visualization"
+	1 to: size do: [ :index |
+		((aCollection at: index) totallyMatches: (otherObject at: index) forTest: self)
+			ifFalse: [ 
+				self logDebugMessage: 'No match collection ' , aCollection fullPrintString , ' with ' , otherObject fullPrintString , ' by elements'.
+				^ false ] ].
+	^ true
+]
+
+{ #category : #'matching helpers' }
+EDATDomainBDD >> working_dictionary: aDictionary totallyMatchesWith: otherObject [
+	| aCollection |
+	self logDebugMessage: 'Checking match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString.
+	aCollection := (OrderedCollection with: aDictionary with: otherObject).
+	(self anyUnnecessaryCheck: aCollection) ifTrue: [ ^ true ].
+	aDictionary == otherObject 
+		ifTrue: [ 
+			self logDebugMessage: 'Match by identity'.
+			^ true ].
+	aDictionary species == otherObject species
+		ifFalse: [
+			self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by different species'.
+			^ false ].
+	(otherObject isKindOf: Dictionary) ifFalse: [ ^ false ].
+	aDictionary size = otherObject size
+		ifFalse: [ 
+			self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by different sizes'.
+			^ false ].
+	"Done like this instead of with allSatisfy: to get all the different values in the future and show them on the visualization"
+	aDictionary associationsDo: [ :assoc |
+		(assoc value totallyMatches: (otherObject at: assoc key ifAbsent: [ ^ false ]) forTest: self)
+			ifFalse: [
+				self logDebugMessage: 'No match dictionary ' , aDictionary fullPrintString , ' with ' , otherObject fullPrintString , ' by elements'. 
+				^ false ] ].
+	^ true
+]
+
+{ #category : #'matching helpers' }
+EDATDomainBDD >> working_event: anEvent totallyMatchesWith: otherEvent [
+	| eventCollection differences |
+	differences := Dictionary with: #match -> true with: #diff -> nil.
+	self checkingLogForType: 'event' element: anEvent and: otherEvent.
+	eventCollection := OrderedCollection with: anEvent with: anEvent.
+	(self anyUnnecessaryCheck: eventCollection)
+		ifTrue: [ ^ differences ].
+	(self areSameEventType: anEvent and: otherEvent)
+		ifFalse: [
+			| message |
+			message := 'No match event ' , anEvent fullPrintString , ' with ' , otherEvent fullPrintString , ' by different event type'.
+			self
+				logDebugMessage: message.
+			differences at: #match put: false.
+			differences at: #diff put: message.
+			^ differences ].
+	anEvent class allInstVarNames
+		allSatisfy: [ :varName | 
+			| varMatch anEventVar otherEventVar |
+			self
+				logDebugMessage: (String streamContents: [ :s | s nextPutAll: 'Checking instance variable '; nextPutAll: varName greaseString ]).
+			anEventVar := (varName value: anEvent).
+			otherEventVar := (varName value: otherEvent).
+			varMatch := 
+				(anEventVar totallyMatches: otherEventVar forTest: self)
+				or: [ | attributeGenerated |
+					attributeGenerated := anEvent class
+						isEventGenerated: varName greaseString.
+					attributeGenerated
+						ifTrue: [ 
+							self logDebugMessage: 
+								(String streamContents: [ :stream | stream nextPutAll: 'Match by '; nextPutAll: varName fullPrintString; nextPutAll: ' event generated' ]) ].
+					attributeGenerated ].
+			varMatch
+				ifTrue: [ self logDebugMessage: (String streamContents: [ :s | s nextPutAll: 'Match ' ; nextPutAll: varName greaseString ]) ]
+				ifFalse: [ 
+					| message |
+					message := String streamContents: [ :s | s nextPutAll: 'No match '; nextPutAll: varName greaseString; nextPut: Character cr; nextPut: Character lf; nextPutAll: anEventVar greaseString; nextPut: Character cr; nextPut: Character lf; nextPutAll: ' with '; nextPut: Character cr; nextPut: Character lf; nextPutAll: otherEventVar greaseString ].
+					self logDebugMessage: message.
+					differences at: #match put: false.
+					differences at: #diff put: message.
+					^ differences ].
+			varMatch ].
+		^ differences 
+]
+
+{ #category : #'matching helpers' }
+EDATDomainBDD >> working_object: anObject totallyMatchesWith: otherObject [
+	| logs aCollection objectsEquality |
+	logs := anObject isCharacter not.
+	logs ifTrue: [ self logDebugMessage: 'Checking match object ' , anObject fullPrintString , ' with ' , otherObject fullPrintString ].
+	aCollection := (OrderedCollection with: anObject with: otherObject).
+	(self anyUnnecessaryCheck: aCollection) ifTrue: [ ^ true ].
+	objectsEquality := anObject = otherObject.
+	logs ifTrue: [ self logDebugMessage: (objectsEquality ifTrue: [ 'Match ' ] ifFalse: [ 'Dismatch ' ]) , ' by identity' ].
+	^ objectsEquality
+
 ]

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -198,6 +198,16 @@ EDATDomainBDD >> buildSampleCommandFor: aCommandClass [
 	^ ATSJsonCommandMaterializer new materialize: commandMessage.
 ]
 
+{ #category : #'helper - command building' }
+EDATDomainBDD >> buildSampleDeleteCommandFor: anAggregateClass [
+	| commandMessage deleteCmd |
+	commandMessage := self readSampleDeleteAggregateCommandFileFor: anAggregateClass.
+	self checkInstVarsFor: EDADeleteAggregateCommand withAttributes: (self buildCommandAttributesDictFromMessage: commandMessage).
+	deleteCmd :=  ATSJsonCommandMaterializer new materialize: commandMessage.
+	deleteCmd aggregateRootClass: nil.
+	^ deleteCmd
+]
+
 { #category : #'helper - event building' }
 EDATDomainBDD >> buildSampleEventFor: anEventClass [
 	| attributes |
@@ -784,6 +794,12 @@ EDATDomainBDD >> readFile: aFile [
 	result := fileStream contents.
 	fileStream close.
 	^ result
+]
+
+{ #category : #'helper - file readers' }
+EDATDomainBDD >> readSampleDeleteAggregateCommandFileFor: anAggregateClass [
+	^ self readFile: ((EDADeleteAggregateCommand sampleFilesPathForTest: self) / ('v' , EDADeleteAggregateCommand latestVersion asString) / 'delete' , (self defaultSampleFileNameFor: anAggregateClass))
+
 ]
 
 { #category : #'helper - file readers' }

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -614,6 +614,11 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 
 { #category : #BDD }
 EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand ofType: aString thenEvents: expectedResultingEvents [
+	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand ofType: aString thenEvents: expectedResultingEvents andAdditionallyAssert: [ :expectedEvents :resultingEvents | true ]
+]
+
+{ #category : #BDD }
+EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand ofType: aString thenEvents: expectedResultingEvents andAdditionallyAssert: anExcepctedAndResultingEventsAssertionBlock [
 	| msg |
 	msg := self
 		buildMessageForCommand: aCommand
@@ -623,6 +628,7 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 		withEvents: historicalEvents
 		whenReceiveMessage: msg
 		thenEvents: expectedResultingEvents
+		andAdditionallyAssert: anExcepctedAndResultingEventsAssertionBlock
 ]
 
 { #category : #BDD }
@@ -657,17 +663,23 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 
 { #category : #BDD }
 EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand thenEvents: expectedResultingEvents [
-	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand ofType: (EDAMessageSerializer nameForMessageClass: aCommand class) thenEvents: expectedResultingEvents 
+	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand thenEvents: expectedResultingEvents andAdditionallyAssert: [ :expectedEvents :resultingEvents | true ]
 
 ]
 
 { #category : #BDD }
-EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveMessage: aString thenEvent: expectedResultingEvent [
-	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveMessage: aString thenEvents: (OrderedCollection with: expectedResultingEvent)
+EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand thenEvents: expectedResultingEvents andAdditionallyAssert: anExcepctedAndResultingEventsAssertionBlock [
+	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveCommand: aCommand ofType: (EDAMessageSerializer nameForMessageClass: aCommand class) thenEvents: expectedResultingEvents andAdditionallyAssert: anExcepctedAndResultingEventsAssertionBlock
+
 ]
 
 { #category : #BDD }
 EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveMessage: aString thenEvents: expectedResultingEvents [
+	^ self givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveMessage: aString thenEvents: expectedResultingEvents andAdditionallyAssert: [ :expectedEvents :resultingEvents | true ]
+]
+
+{ #category : #BDD }
+EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEvents whenReceiveMessage: aString thenEvents: expectedResultingEvents andAdditionallyAssert: anExcepctedAndResultingEventsAssertionBlock [
 	| commandConsumer resultingEvents mock eventStore expectedEvents eventsToSave aggregateRootVersion msg eventsOfAggregate originalEventStores |
 	mock := EDAAcceptEverything new.
 	eventStore := EDAVolatileEventStore new.
@@ -717,7 +729,8 @@ EDATDomainBDD >> givenAggregate: anAggregateRootSymbol withEvents: historicalEve
 			"self assert: expected asJsonString equals: actual asJsonString."
 			"self assertEvent: expected equals: actual."
 			"self assert: expected equals: actual."
-			"self assertEvent: expected matches: actual" ] ]
+			"self assertEvent: expected matches: actual" ].
+	anExcepctedAndResultingEventsAssertionBlock value: expectedEvents value: resultingEvents ]
 		ensure: [ self restoreEventStores: originalEventStores ]
 ]
 

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -66,7 +66,7 @@ EDATDomainBDD >> assertEvent: actual deepMatches: expected [
 	"
 	[ self event: expected totallyMatchesWith: actual ]
 		on: EDAMismatchError
-		do: [ self assert: expected asJsonString equals: actual asJsonString ]
+		do: [ :ex | self assert: expected asJsonString equals: actual asJsonString ]
 ]
 
 { #category : #BDD }

--- a/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
+++ b/src/EDA-Domain-Tests/EDATDomainBDD.trait.st
@@ -1,6 +1,7 @@
 Trait {
 	#name : #EDATDomainBDD,
 	#traits : 'EDATLogging + EDATRegexHelper',
+	#classTraits : 'EDATLogging classTrait + EDATRegexHelper classTrait',
 	#category : #'EDA-Domain-Tests'
 }
 
@@ -527,8 +528,8 @@ EDATDomainBDD >> event: anEvent totallyMatchesWith: otherEvent [
 		ifFalse: [ | mismatchTypeLogMessage |
 			mismatchTypeLogMessage := self mismatchCheckLogForType: checkingType element: anEvent and: otherEvent andReason: 'by different types'.
 			self logDebugMessage: mismatchTypeLogMessage.
-			eventDiffMessage add: anEvent -> otherEvent.
-			EDAMismatchError signal: mismatchTypeLogMessage withDiff: eventDiffMessage ].
+			eventDiffDict add: anEvent -> otherEvent.
+			EDAMismatchError signal: mismatchTypeLogMessage withDiff: eventDiffDict ].
 	anEvent class allInstVarNames
 		do: [ :varName | 
 			| checkingInstVarMessage anEventVar otherEventVar |

--- a/src/EDA-Domain/EDAAggregateRoot.class.st
+++ b/src/EDA-Domain/EDAAggregateRoot.class.st
@@ -42,6 +42,11 @@ EDAAggregateRoot class >> checkTenantIsValid: tenantOfCommand [
 ]
 
 { #category : #helpers }
+EDAAggregateRoot class >> classPrefix [
+	^ (self name regex: '^([A-Z]+)' matchesCollect: [ :each | each asString ]) first allButLast
+]
+
+{ #category : #helpers }
 EDAAggregateRoot class >> newVersionAfter: aVersion [
 	^ aVersion + 1
 ]

--- a/src/EDA-Events/EDADeleteCommandResultEvent.class.st
+++ b/src/EDA-Events/EDADeleteCommandResultEvent.class.st
@@ -1,11 +1,19 @@
 Class {
 	#name : #EDADeleteCommandResultEvent,
 	#superclass : #EDACommandResultEvent,
-	#category : 'EDA-Events-Events'
+	#category : #'EDA-Events-Events'
 }
 
 { #category : #'generated-v1' }
 EDADeleteCommandResultEvent class >> ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs [
+	| result |
+	result := super ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs.
+	result timestamp: DateAndTime now asUTC.
+	^ result
+]
+
+{ #category : #'generated-v1' }
+EDADeleteCommandResultEvent class >> old_ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs [
 	| result |
 	result := super ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs.
 	result timestamp: DateAndTime now asUTC.

--- a/src/EDA-Events/EDAEventSourcingEvent.class.st
+++ b/src/EDA-Events/EDAEventSourcingEvent.class.st
@@ -29,8 +29,8 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #EDAEventSourcingEvent,
 	#superclass : #Announcement,
-	#traits : 'EDAPrintOnHelper + EDATHashHelper + EDATEqualsHelper',
-	#classTraits : 'EDAPrintOnHelper classTrait + EDATHashHelper classTrait + EDATEqualsHelper classTrait',
+	#traits : 'EDAPrintOnHelper + EDATHashHelper + EDATEqualsHelper + EDATLogging',
+	#classTraits : 'EDAPrintOnHelper classTrait + EDATHashHelper classTrait + EDATEqualsHelper classTrait + EDATLogging classTrait',
 	#instVars : [
 		'id',
 		'timestamp',
@@ -60,6 +60,11 @@ EDAEventSourcingEvent class >> attributesWhoseValuesGetGenerated [
 	^ #('id' 'timestamp') asSet
 ]
 
+{ #category : #helpers }
+EDAEventSourcingEvent class >> classPrefix [
+	^ (self name regex: '^([A-Z]+)' matchesCollect: [ :each | each asString ]) first allButLast
+]
+
 { #category : #meta }
 EDAEventSourcingEvent class >> isEventGenerated: attr [
 	^ self attributesWhoseValuesGetGenerated anySatisfy: [ :v | v = attr ]
@@ -73,6 +78,39 @@ EDAEventSourcingEvent class >> latestVersion [
 
 { #category : #meta }
 EDAEventSourcingEvent class >> ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs [
+	| event previousAggregateRootVersion aggregateRootVersion |
+	event := self new.
+	event tenant: theTenant.
+	event id: theId.
+	event commandId: theCommandId.
+	event
+		timestamp: (theAttrs at: 'timestamp' ifAbsent: [ DateAndTime now asUTC ]).
+	previousAggregateRootVersion :=  theAttrs at: 'aggregateRootVersion' ifAbsent: [ nil ].
+	aggregateRootVersion := previousAggregateRootVersion ifNil: [ 1 ] ifNotNil: [ :pARV | pARV + 1 ].
+	event aggregateRootVersion: aggregateRootVersion.
+	event version: self latestVersion.
+	(self allInstVarNames reject: [ :var | #(#aggregateRootClass #aggregateRootVersion #commandId #delete #id #tenant #timestamp #version) includes: var ])
+		do: [ :instVarName |
+			| value |
+			value := theAttrs at: instVarName ifAbsent: [ nil ].
+			"do not set the new value if it is nil to avoid removing the initialized values"
+			value ifNotNil: [ 
+				event
+					instVarNamed: instVarName asString
+					put: value
+					ifAbsent: [ 
+						self logWarningMessage: 
+							(String streamContents: [ :stream |
+								stream nextPutAll:  'No such inst var ['.
+								stream nextPutAll: instVarName greaseString.
+								stream nextPutAll: '] to set in ['.
+								stream nextPutAll: self name.
+								stream nextPutAll: ']' ]) ]	] ].
+	^ event
+]
+
+{ #category : #meta }
+EDAEventSourcingEvent class >> old_ofTenant: theTenant withAggregateId: theId commandId: theCommandId andAttributes: theAttrs [
 	| result scopeKey scopeContext previousAggregateRootVersion aggregateRootVersion |
 	result := self new.
 	result tenant: theTenant.
@@ -126,8 +164,9 @@ EDAEventSourcingEvent >> aggregateRootVersion: anObject [
 { #category : #accessing }
 EDAEventSourcingEvent >> delete [
 	self flag: #TODO. "Find out why initialize doesn't get called for EDAEventSourcingEvents"
-	delete ifNil: [ self initialize ].
-	^ delete
+	^ delete ifNil: [ delete := false ]
+"	delete ifNil: [ self initialize ].
+	^ delete"
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- Change domain test framework to work properly.
- Change the test helper methods by generalizing them to any command and event.
- Create a generic event constructor, avoiding creating one for each different type of event.